### PR TITLE
Fix issues with running `lein ring server`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,8 +11,8 @@
                  [clj-time "0.15.0"]
                  [http-kit "2.3.0"]
                  [org.clojure/data.json "0.2.6"]]
-  :plugins [[lein-ring "0.12.4"]]
-  :ring {:handler ubc-website.handler/app}
+  :plugins [[lein-ring "0.12.5"]]
+  :ring {:handler ubc-website.routes/app}
   :profiles
   {:dev
    [{:plugins [[com.jakemccrary/lein-test-refresh "0.23.0"]]}

--- a/src/ubc_website/main.clj
+++ b/src/ubc_website/main.clj
@@ -6,5 +6,5 @@
 
 
 (defn -main []
-  (run-server (app) {:port 3000})
+  (run-server app {:port 3000})
 )

--- a/src/ubc_website/routes.clj
+++ b/src/ubc_website/routes.clj
@@ -41,5 +41,5 @@
                      (handler request))]
       response)))
 
-(defn app []
+(def app
   (-> app-routes wrap-reload wrap-markdown))


### PR DESCRIPTION
Hi,

I come across your repo by accident and while checking it out I found two minor issues related to lein-ring. I noticed that you probably run the app from main and the usage of lein-ring might be obsolate here. Despite that if in any case you wanted to keep lein-ring, this PR might help you. Otherwise please decline it.

----

* Fix issues with running `lein ring server`

    1) Compatibility issue: lein-ring and latest leiningen

        ```
        clojure.lang.Compiler$CompilerException: Syntax error macroexpanding clojure.core/fn at (clojure/core/unify.clj:83:18).
        ```
        `lein-ring` seems to be uncompatible with Leiningen 2.9.0 and above.

       Similar issues:
        * https://github.com/Azure/draft/issues/932
        * https://translate.google.com/translate?hl=en&sl=zh-CN&u=https://xbuba.com/questions/54810552&prev=search

    2) Incorrect lein-ring handler

        lein-ring had a wrong reference, but even if it was correct it should to be a handler not a fn.
        Since evaluation of app at boot doesn't seem to be harmful, I let myself to change it.